### PR TITLE
BaSP-Hotfix: Add modal when error become from server connection fail.

### DIFF
--- a/src/Components/Auth/SingUp/index.js
+++ b/src/Components/Auth/SingUp/index.js
@@ -23,8 +23,9 @@ const SignUp = () => {
     resolver: joiResolver(signupSchema)
   });
 
-  const onSubmit = (inputData) => {
-    dispatch(createEmployee(inputData));
+  const onSubmit = async (inputData) => {
+    const authenticated = await dispatch(createEmployee(inputData));
+    authenticated && history.push('/home');
   };
 
   return (

--- a/src/Components/Share/Modal/modal.module.css
+++ b/src/Components/Share/Modal/modal.module.css
@@ -77,6 +77,12 @@
     font-size: 1.1rem;
 }
 
+.reference {
+    font-weight: 500;
+    text-decoration: underline;
+    color: var(--color-green-primary);
+}
+
 .buttonsContainer {
     display: flex;
     justify-content: flex-end;

--- a/src/redux/employees/thunks.js
+++ b/src/redux/employees/thunks.js
@@ -148,8 +148,23 @@ export const createEmployee = (body) => {
         dispatch(fetchDataOff());
       }
     } catch (error) {
+      dispatch(
+        setModalContent(
+          <>
+            <h3 className={modalStyles.title}>Error: Cant connect with server!</h3>
+            <p className={modalStyles.info}>Mmmm!! Something was wrong with you registration.</p>
+            <p className={modalStyles.info}>
+              Check your internet connection please! If error persist try in a few minutes or{' '}
+              <a href={'/home'} className={modalStyles.reference}>
+                contact us.
+              </a>
+            </p>
+          </>
+        )
+      );
+      dispatch(setShowModal(true));
+      dispatch(fetchDataOff());
       console.error(error);
-      // dispatch(fetchDataOff());
     }
   };
 };

--- a/src/redux/employees/thunks.js
+++ b/src/redux/employees/thunks.js
@@ -143,9 +143,11 @@ export const createEmployee = (body) => {
               )
         );
         dispatch(setShowModal(true));
+        return false;
       } else {
         dispatch(login(body));
         dispatch(fetchDataOff());
+        return true;
       }
     } catch (error) {
       dispatch(
@@ -165,6 +167,7 @@ export const createEmployee = (body) => {
       dispatch(setShowModal(true));
       dispatch(fetchDataOff());
       console.error(error);
+      return false;
     }
   };
 };


### PR DESCRIPTION
**Fix missing modal with error message when unable to connect to the server when creating a new employee.**


![image](https://user-images.githubusercontent.com/96196361/205973844-5aaab658-bd85-4b4c-922a-bd1f245bf514.png)


When the server is offline, because the user does not have internet or because of any problem with data fetching, previously no message was being displayed from the UI.

Added a handling of that instance to show a modal with the error.

> Steps to reply error:

- Download App github repo.

- Open gitbash or any other console.

- Move to repo’s folder (or GitBash here)

- Type git checkout master

- `npm start` (before check if your repo is up to date with `npm install` )

- Try to Sign Up without start server!! → this is very importat and required!!

- And then when stop fetching you will see same page whit a missing modal error message.

> After that you can type `git checkout hotfix/TG-84/modal-when-offline` and try same steps.